### PR TITLE
chore(pom): upgrade `maven-javadoc-plugin` from `2.10.3` to `2.10.4`

### DIFF
--- a/spring-data-mock/pom.xml
+++ b/spring-data-mock/pom.xml
@@ -311,7 +311,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <!-- deployment -->
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
-        <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.0.0</maven-source-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.7</nexus-staging-maven-plugin.version>


### PR DESCRIPTION
Closes #95