### PR TITLE
Fix delete when entity class implements serializable interface

### DIFF
--- a/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/repository/DefaultCrudRepository.java
+++ b/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/repository/DefaultCrudRepository.java
@@ -26,7 +26,6 @@ public class DefaultCrudRepository extends CrudRepositorySupport {
 
     /**
      * Saves all the given entities
-     *
      * @param entities entities to save (insert or update)
      * @return saved entities
      */
@@ -42,7 +41,6 @@ public class DefaultCrudRepository extends CrudRepositorySupport {
 
     /**
      * Finds the entity that was saved with this key, or returns {@literal null}
-     *
      * @param key the key
      * @return the entity
      */
@@ -53,7 +51,6 @@ public class DefaultCrudRepository extends CrudRepositorySupport {
 
     /**
      * Checks whether the given key represents an entity in the data store
-     *
      * @param key the key
      * @return {@literal true} if the key is valid
      */
@@ -63,7 +60,6 @@ public class DefaultCrudRepository extends CrudRepositorySupport {
 
     /**
      * Finds all the entities that match the given set of ids
-     *
      * @param ids ids to look for
      * @return entities that matched the ids.
      */
@@ -84,7 +80,6 @@ public class DefaultCrudRepository extends CrudRepositorySupport {
     /**
      * Deletes the entity with the given id and returns the actual entity that
      * was just deleted.
-     *
      * @param id the id
      * @return the entity that was deleted or {@literal null} if it wasn't found
      */
@@ -92,7 +87,7 @@ public class DefaultCrudRepository extends CrudRepositorySupport {
         Object retrieved = getDataStore().retrieve(id);
         log.info("Attempting to delete the entity with key " + id);
         if (retrieved == null) {
-            log.info("Object not found with key " + id + ", try to find by identyfier property");
+            log.info("Object not found with key " + id + ", try to find by identifier property");
             try {
                 id = (Serializable) PropertyUtils.getPropertyValue(id, getRepositoryMetadata().getIdentifierProperty());
                 retrieved = getDataStore().retrieve(id);
@@ -106,7 +101,6 @@ public class DefaultCrudRepository extends CrudRepositorySupport {
 
     /**
      * Deletes the entity matching this entity's key from the data store
-     *
      * @param entity the entity
      * @return the deleted entity
      * @throws EntityMissingKeyException if the passed entity doesn't have a key
@@ -122,7 +116,6 @@ public class DefaultCrudRepository extends CrudRepositorySupport {
 
     /**
      * Deletes all specified <em>entities</em> from the data store.
-     *
      * @param entities the entities to delete
      * @return the entities that were actually deleted
      */
@@ -142,7 +135,6 @@ public class DefaultCrudRepository extends CrudRepositorySupport {
 
     /**
      * Deletes everything from the data store
-     *
      * @return all the entities that were removed
      */
     public Iterable deleteAll() {

--- a/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/repository/DefaultCrudRepository.java
+++ b/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/repository/DefaultCrudRepository.java
@@ -11,7 +11,9 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
- * <p>This class will provide implementations for the methods introduced by the Spring framework through
+ * <p>
+ * This class will provide implementations for the methods introduced by the
+ * Spring framework through
  * {@link org.springframework.data.repository.CrudRepository}.</p>
  *
  * @author Milad Naseri (mmnaseri@programmer.net)
@@ -24,7 +26,8 @@ public class DefaultCrudRepository extends CrudRepositorySupport {
 
     /**
      * Saves all the given entities
-     * @param entities    entities to save (insert or update)
+     *
+     * @param entities entities to save (insert or update)
      * @return saved entities
      */
     public Iterable<Object> save(Iterable entities) {
@@ -39,7 +42,8 @@ public class DefaultCrudRepository extends CrudRepositorySupport {
 
     /**
      * Finds the entity that was saved with this key, or returns {@literal null}
-     * @param key    the key
+     *
+     * @param key the key
      * @return the entity
      */
     public Object findOne(Serializable key) {
@@ -49,7 +53,8 @@ public class DefaultCrudRepository extends CrudRepositorySupport {
 
     /**
      * Checks whether the given key represents an entity in the data store
-     * @param key    the key
+     *
+     * @param key the key
      * @return {@literal true} if the key is valid
      */
     public boolean exists(Serializable key) {
@@ -58,7 +63,8 @@ public class DefaultCrudRepository extends CrudRepositorySupport {
 
     /**
      * Finds all the entities that match the given set of ids
-     * @param ids    ids to look for
+     *
+     * @param ids ids to look for
      * @return entities that matched the ids.
      */
     public Iterable findAll(Iterable ids) {
@@ -76,19 +82,32 @@ public class DefaultCrudRepository extends CrudRepositorySupport {
     }
 
     /**
-     * Deletes the entity with the given id and returns the actual entity that was just deleted.
-     * @param id    the id
+     * Deletes the entity with the given id and returns the actual entity that
+     * was just deleted.
+     *
+     * @param id the id
      * @return the entity that was deleted or {@literal null} if it wasn't found
      */
     public Object delete(Serializable id) {
-        final Object retrieved = getDataStore().retrieve(id);
+        Object retrieved = getDataStore().retrieve(id);
+        log.info("Attempting to delete the entity with key " + id);
+        if (retrieved == null) {
+            log.info("Object not found with key " + id + ", try to find by identyfier property");
+            try {
+                id = (Serializable) PropertyUtils.getPropertyValue(id, getRepositoryMetadata().getIdentifierProperty());
+                retrieved = getDataStore().retrieve(id);
+            } catch (IllegalStateException exception) {
+                log.info("Serialized id doesn't have a identifier property");
+            }
+        }
         getDataStore().delete(id);
         return retrieved;
     }
 
     /**
      * Deletes the entity matching this entity's key from the data store
-     * @param entity    the entity
+     *
+     * @param entity the entity
      * @return the deleted entity
      * @throws EntityMissingKeyException if the passed entity doesn't have a key
      */
@@ -103,7 +122,8 @@ public class DefaultCrudRepository extends CrudRepositorySupport {
 
     /**
      * Deletes all specified <em>entities</em> from the data store.
-     * @param entities    the entities to delete
+     *
+     * @param entities the entities to delete
      * @return the entities that were actually deleted
      */
     public Iterable delete(Iterable entities) {
@@ -122,6 +142,7 @@ public class DefaultCrudRepository extends CrudRepositorySupport {
 
     /**
      * Deletes everything from the data store
+     *
      * @return all the entities that were removed
      */
     public Iterable deleteAll() {

--- a/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/repository/DefaultCrudRepositoryWithSerializedTest.java
+++ b/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/repository/DefaultCrudRepositoryWithSerializedTest.java
@@ -1,0 +1,51 @@
+package com.mmnaseri.utils.spring.data.repository;
+
+import com.mmnaseri.utils.spring.data.domain.impl.ImmutableRepositoryMetadata;
+import com.mmnaseri.utils.spring.data.domain.impl.key.UUIDKeyGenerator;
+import com.mmnaseri.utils.spring.data.sample.models.PersonSerializable;
+import com.mmnaseri.utils.spring.data.sample.repositories.SimplePersonSerializableRepository;
+import com.mmnaseri.utils.spring.data.store.DataStore;
+import com.mmnaseri.utils.spring.data.store.impl.MemoryDataStore;
+import org.hamcrest.Matchers;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.testng.Assert.fail;
+
+/**
+ * @author Milad Naseri (mmnaseri@programmer.net)
+ * @since 1.0 (4/11/16, 10:15 AM)
+ */
+public class DefaultCrudRepositoryWithSerializedTest {
+
+    private DefaultCrudRepository repository;
+    private DataStore<String, PersonSerializable> dataStore;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        dataStore = new MemoryDataStore<>(PersonSerializable.class);
+        repository = new DefaultCrudRepository();
+        repository.setRepositoryMetadata(new ImmutableRepositoryMetadata(String.class, PersonSerializable.class, SimplePersonSerializableRepository.class, "id"));
+        repository.setDataStore(dataStore);
+        repository.setKeyGenerator(new UUIDKeyGenerator());
+    }
+
+
+    @Test
+    public void testDeleteByEntityWhenEntityHasKey() throws Exception {
+        final PersonSerializable original = new PersonSerializable();
+        dataStore.save("1", original);
+        assertThat(dataStore.hasKey("1"), is(true));
+        final PersonSerializable personToDelete = new PersonSerializable();
+        personToDelete.setId("1");
+        final Object deleted = repository.delete(personToDelete);
+        assertThat(dataStore.hasKey("1"), is(false));
+        assertThat(deleted, is(notNullValue()));
+        assertThat(deleted, Matchers.<Object>is(original));
+    }
+
+
+}

--- a/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/sample/models/PersonSerializable.java
+++ b/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/sample/models/PersonSerializable.java
@@ -1,0 +1,21 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.mmnaseri.utils.spring.data.sample.models;
+
+import java.io.Serializable;
+
+/**
+ *
+ * @author blackleg
+ */
+public class PersonSerializable extends Person implements Serializable {
+
+    @Override
+    public String getId() {
+        return super.getId(); //To change body of generated methods, choose Tools | Templates.
+    }
+
+}

--- a/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/sample/repositories/SimplePersonSerializableRepository.java
+++ b/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/sample/repositories/SimplePersonSerializableRepository.java
@@ -1,0 +1,17 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.mmnaseri.utils.spring.data.sample.repositories;
+
+import com.mmnaseri.utils.spring.data.sample.models.PersonSerializable;
+import org.springframework.data.repository.Repository;
+
+/**
+ *
+ * @author blackleg
+ */
+public interface SimplePersonSerializableRepository  extends Repository<PersonSerializable, String> {
+    
+}


### PR DESCRIPTION
In CrudRepository when it try to delete a entity that implements serializable interface, the delete function by key is called and the entity isn't found.

