### PR TITLE
Fix save iterables

### DIFF
--- a/spring-data-mock/pom.xml
+++ b/spring-data-mock/pom.xml
@@ -200,7 +200,6 @@
                 <configuration>
                     <source>${target-jdk.version}</source>
                     <target>${target-jdk.version}</target>
-                    <showDeprecation>false</showDeprecation>
                 </configuration>
             </plugin>
         </plugins>

--- a/spring-data-mock/pom.xml
+++ b/spring-data-mock/pom.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Milad Naseri
-  ~
-  ~ Permission is hereby granted, free of charge, to any person obtaining a copy of this
-  ~ software and associated documentation files (the "Software"), to deal in the Software
-  ~ without restriction, including without limitation the rights to use, copy, modify, merge,
-  ~ publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
-  ~ to whom the Software is furnished to do so, subject to the following conditions:
-  ~
-  ~ The above copyright notice and this permission notice shall be included in all copies or
-  ~ substantial portions of the Software.
-  ~
-  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
-  ~ INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
-  ~ PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
-  ~ FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-  ~ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-  ~ SOFTWARE.
-  -->
+~ Copyright (c) 2016 Milad Naseri
+~
+~ Permission is hereby granted, free of charge, to any person obtaining a copy of this
+~ software and associated documentation files (the "Software"), to deal in the Software
+~ without restriction, including without limitation the rights to use, copy, modify, merge,
+~ publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+~ to whom the Software is furnished to do so, subject to the following conditions:
+~
+~ The above copyright notice and this permission notice shall be included in all copies or
+~ substantial portions of the Software.
+~
+~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+~ INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+~ PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+~ FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+~ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+~ SOFTWARE.
+-->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -73,6 +73,7 @@
         <!-- test -->
         <testng.version>6.9.12</testng.version>
         <hamcrest.version>1.3</hamcrest.version>
+        <slf4j-simple.version>1.7.21</slf4j-simple.version>
         <!-- deployment -->
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
@@ -129,6 +130,12 @@
             <groupId>javax.persistence</groupId>
             <artifactId>persistence-api</artifactId>
             <version>${persistence-api.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j-simple.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- dependencies for adding support for various features of the spring data ecosystem -->
@@ -193,6 +200,7 @@
                 <configuration>
                     <source>${target-jdk.version}</source>
                     <target>${target-jdk.version}</target>
+                    <showDeprecation>false</showDeprecation>
                 </configuration>
             </plugin>
         </plugins>

--- a/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/proxy/impl/resolvers/SignatureDataOperationResolver.java
+++ b/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/proxy/impl/resolvers/SignatureDataOperationResolver.java
@@ -42,8 +42,8 @@ public class SignatureDataOperationResolver implements DataOperationResolver {
             final Class<?> type = mapping.getType();
             final Method declaration = findMethod(type, method.getName(), method.getParameterTypes());
             if (declaration != null) {
-                log.info("Setting the resolution as a method invocation on the previously prepared type mapping");
                 final Object instance = mapping.getInstance();
+                log.info("Setting the resolution as a method invocation on the previously prepared type mapping with method " + declaration);
                 return new MethodInvocationDataStoreOperation<Serializable, Object>(instance, declaration);
             }
         }
@@ -54,9 +54,9 @@ public class SignatureDataOperationResolver implements DataOperationResolver {
         log.debug("Attempting to look for the actual declaration of the method named '" + name + "' with parameter types " + Arrays.toString(parameterTypes) + " on the child type " + type);
         Class<?> searchType = type;
         while (searchType != null) {
-            log.trace("Looking at type " + type + " for method " + name);
             final Method[] methods = searchType.isInterface() ? searchType.getMethods() : searchType.getDeclaredMethods();
             for (Method method : methods) {
+                log.trace("Looking at type " + type + " for method " + name + " with method " + method);
                 if (method.getName().equals(name) && parameterTypes.length == method.getParameterTypes().length) {
                     boolean matches = true;
                     for (int i = 0; i < parameterTypes.length; i++) {

--- a/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/repository/CrudRepositorySupport.java
+++ b/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/repository/CrudRepositorySupport.java
@@ -55,7 +55,7 @@ public class CrudRepositorySupport implements DataStoreAware, RepositoryMetadata
      * @param entities entities to save (insert or update)
      * @return saved entities
      */
-    public Iterable save(Iterable entities) {
+    public Iterable<Object> save(Iterable<?> entities) {
         List<Object> list = new LinkedList<>();
         LOG.info("Going to save a number of entities in the underlying data store");
         LOG.debug(entities);

--- a/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/repository/DefaultCrudRepository.java
+++ b/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/repository/DefaultCrudRepository.java
@@ -25,21 +25,6 @@ public class DefaultCrudRepository extends CrudRepositorySupport {
     private static final Log log = LogFactory.getLog(DefaultCrudRepository.class);
 
     /**
-     * Saves all the given entities
-     * @param entities entities to save (insert or update)
-     * @return saved entities
-     */
-    public Iterable<Object> save(Iterable entities) {
-        final List<Object> list = new LinkedList<>();
-        log.info("Going to save a number of entities in the underlying data store");
-        log.debug(entities);
-        for (Object entity : entities) {
-            list.add(save(entity));
-        }
-        return list;
-    }
-
-    /**
      * Finds the entity that was saved with this key, or returns {@literal null}
      * @param key the key
      * @return the entity

--- a/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/dsl/mock/MockedRepositoryTest.java
+++ b/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/dsl/mock/MockedRepositoryTest.java
@@ -47,6 +47,7 @@ public class MockedRepositoryTest {
     public void testSaveList() {
         List<Person> people = Person.list();
         List<Person> savedPeople = repository.save(people);
+        assertThat(savedPeople, is(notNullValue()));
         assertThat(repository.findAll(), is(notNullValue()));
         assertThat(repository.findAll(), hasSize(1));
     }

--- a/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/dsl/mock/MockedRepositoryTest.java
+++ b/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/dsl/mock/MockedRepositoryTest.java
@@ -19,7 +19,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /**
- *
+ * MockedRepositoryTest
  * @author blackleg
  */
 public class MockedRepositoryTest {

--- a/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/dsl/mock/MockedRepositoryTest.java
+++ b/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/dsl/mock/MockedRepositoryTest.java
@@ -1,7 +1,21 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright (c) 2016 Milad Naseri
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+ * to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 package com.mmnaseri.utils.spring.data.dsl.mock;
 
@@ -20,19 +34,19 @@ import org.testng.annotations.Test;
 
 /**
  * MockedRepositoryTest
+ *
  * @author blackleg
  */
 public class MockedRepositoryTest {
-    
+
     private JpaPersonRepository repository;
-    
+
     @BeforeMethod
     public void setUp() throws Exception {
         repository = new RepositoryMockBuilder().useConfiguration(RepositoryFactoryBuilder.defaultConfiguration()).mock(JpaPersonRepository.class);
         assertThat(repository, is(notNullValue()));
     }
-    
-    
+
     @Test
     public void testSave() {
         Person person = repository.save(Person.build());
@@ -42,7 +56,7 @@ public class MockedRepositoryTest {
         repository.delete(person);
         assertThat(repository.findAll(), is(empty()));
     }
-    
+
     @Test
     public void testSaveList() {
         List<Person> people = Person.list();
@@ -51,5 +65,5 @@ public class MockedRepositoryTest {
         assertThat(repository.findAll(), is(notNullValue()));
         assertThat(repository.findAll(), hasSize(1));
     }
-    
+
 }

--- a/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/dsl/mock/MockedRepositoryTest.java
+++ b/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/dsl/mock/MockedRepositoryTest.java
@@ -1,0 +1,54 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.mmnaseri.utils.spring.data.dsl.mock;
+
+import com.mmnaseri.utils.spring.data.dsl.factory.RepositoryFactoryBuilder;
+import com.mmnaseri.utils.spring.data.sample.models.Person;
+import com.mmnaseri.utils.spring.data.sample.repositories.JpaPersonRepository;
+import java.util.List;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ *
+ * @author blackleg
+ */
+public class MockedRepositoryTest {
+    
+    private JpaPersonRepository repository;
+    
+    @BeforeMethod
+    public void setUp() throws Exception {
+        repository = new RepositoryMockBuilder().useConfiguration(RepositoryFactoryBuilder.defaultConfiguration()).mock(JpaPersonRepository.class);
+        assertThat(repository, is(notNullValue()));
+    }
+    
+    
+    @Test
+    public void testSave() {
+        Person person = repository.save(Person.build());
+        assertThat(repository.findAll(), is(notNullValue()));
+        assertThat(repository.findAll(), hasSize(1));
+        assertThat(repository.findAll(), hasItem(person));
+        repository.delete(person);
+        assertThat(repository.findAll(), is(empty()));
+    }
+    
+    @Test
+    public void testSaveList() {
+        List<Person> people = Person.list();
+        List<Person> savedPeople = repository.save(people);
+        assertThat(repository.findAll(), is(notNullValue()));
+        assertThat(repository.findAll(), hasSize(1));
+    }
+    
+}

--- a/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/repository/DefaultCrudRepositoryWithSerializedTest.java
+++ b/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/repository/DefaultCrudRepositoryWithSerializedTest.java
@@ -6,14 +6,13 @@ import com.mmnaseri.utils.spring.data.sample.models.PersonSerializable;
 import com.mmnaseri.utils.spring.data.sample.repositories.SimplePersonSerializableRepository;
 import com.mmnaseri.utils.spring.data.store.DataStore;
 import com.mmnaseri.utils.spring.data.store.impl.MemoryDataStore;
+import static org.hamcrest.MatcherAssert.assertThat;
 import org.hamcrest.Matchers;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.testng.Assert.fail;
 
 /**
  * @author Milad Naseri (mmnaseri@programmer.net)
@@ -36,16 +35,15 @@ public class DefaultCrudRepositoryWithSerializedTest {
 
     @Test
     public void testDeleteByEntityWhenEntityHasKey() throws Exception {
-        final PersonSerializable original = new PersonSerializable();
+        final PersonSerializable original = PersonSerializable.build();
         dataStore.save("1", original);
         assertThat(dataStore.hasKey("1"), is(true));
-        final PersonSerializable personToDelete = new PersonSerializable();
+        final PersonSerializable personToDelete = PersonSerializable.build();
         personToDelete.setId("1");
         final Object deleted = repository.delete(personToDelete);
         assertThat(dataStore.hasKey("1"), is(false));
         assertThat(deleted, is(notNullValue()));
         assertThat(deleted, Matchers.<Object>is(original));
     }
-
-
+    
 }

--- a/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/sample/models/Person.java
+++ b/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/sample/models/Person.java
@@ -92,7 +92,7 @@ public class Person {
     }
 
     public static List<Person> list(int count) {
-        ArrayList<Person> people = new ArrayList();
+        ArrayList<Person> people = new ArrayList<>();
         for (int i = 0; i < count; i++) {
             people.add(Person.build());
         }

--- a/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/sample/models/Person.java
+++ b/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/sample/models/Person.java
@@ -1,11 +1,14 @@
 package com.mmnaseri.utils.spring.data.sample.models;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * @author Milad Naseri (mmnaseri@programmer.net)
  * @since 1.0 (9/21/15)
  */
 public class Person {
-
+    
     private String id;
     private String firstName;
     private String lastName;
@@ -82,6 +85,22 @@ public class Person {
     @Override
     public int hashCode() {
         return id != null ? id.hashCode() : 0;
+    }
+    
+    public static Person build() {
+        return new Person();
+    }
+
+    public static List<Person> list(int count) {
+        ArrayList<Person> people = new ArrayList();
+        for (int i = 0; i < count; i++) {
+            people.add(Person.build());
+        }
+        return people;
+    }
+    
+    public static List<Person> list() {
+        return list(1);
     }
 
 }

--- a/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/sample/models/PersonSerializable.java
+++ b/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/sample/models/PersonSerializable.java
@@ -6,6 +6,8 @@
 package com.mmnaseri.utils.spring.data.sample.models;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  *
@@ -16,6 +18,23 @@ public class PersonSerializable extends Person implements Serializable {
     @Override
     public String getId() {
         return super.getId(); //To change body of generated methods, choose Tools | Templates.
+    }
+    
+    
+    public static PersonSerializable build() {
+        return new PersonSerializable();
+    }
+    
+    public static List<PersonSerializable> getList(int count) {
+        ArrayList<PersonSerializable> list = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            list.add(PersonSerializable.build());
+        }
+        return list;
+    }
+    
+    public static List<PersonSerializable> getList() {
+        return getList(3);
     }
 
 }

--- a/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/sample/repositories/JpaPersonRepository.java
+++ b/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/sample/repositories/JpaPersonRepository.java
@@ -1,0 +1,17 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.mmnaseri.utils.spring.data.sample.repositories;
+
+import com.mmnaseri.utils.spring.data.sample.models.Person;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ *
+ * @author blackleg
+ */
+public interface JpaPersonRepository extends JpaRepository<Person, String> {
+    
+}


### PR DESCRIPTION
Fix save iterables in CrudRepository.save(Iterable) https://github.com/mmnaseri/spring-data-mock/issues/143

When you try to save List in a CrudRepository and DefaultJpaRepository is enabled, SignatureDataOperationResolver found the save(Object) method from DefaultJpaRepository before the save(Iterate) method from DefaultCrudRepository.

It is because DefaultJpaRepository extends CrudRepositorySupport.

