### PR TITLE
feat(core): Add support for default interface methods

### DIFF
--- a/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/proxy/NonDataOperationHandler.java
+++ b/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/proxy/NonDataOperationHandler.java
@@ -28,8 +28,9 @@ public interface NonDataOperationHandler {
    * indeed handle this method invocation.
    *
    * @param proxy the proxy object
+   * @param method the method being called
    * @param args the arguments
    * @return the result
    */
-  Object invoke(Object proxy, Object... args);
+  Object invoke(Object proxy, Method method, Object... args);
 }

--- a/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/proxy/impl/DefaultRepositoryFactory.java
+++ b/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/proxy/impl/DefaultRepositoryFactory.java
@@ -275,6 +275,9 @@ public class DefaultRepositoryFactory implements RepositoryFactory {
       DataOperationResolver operationResolver, Method[] methods) {
     final List<InvocationMapping<?, ?>> invocationMappings = new LinkedList<>();
     for (Method method : methods) {
+      if (method.isDefault()) {
+        continue;
+      }
       final DataStoreOperation<?, ?, ?> operation = operationResolver.resolve(method);
       //noinspection unchecked
       invocationMappings.add(

--- a/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/proxy/impl/NonDataOperationInvocationHandler.java
+++ b/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/proxy/impl/NonDataOperationInvocationHandler.java
@@ -4,6 +4,7 @@ import com.mmnaseri.utils.spring.data.error.UnknownDataOperationException;
 import com.mmnaseri.utils.spring.data.proxy.NonDataOperationHandler;
 import com.mmnaseri.utils.spring.data.proxy.impl.regular.EqualsNonDataOperationHandler;
 import com.mmnaseri.utils.spring.data.proxy.impl.regular.HashCodeNonDataOperationHandler;
+import com.mmnaseri.utils.spring.data.proxy.impl.regular.InterfaceDefaultMethodNonDataOperation;
 import com.mmnaseri.utils.spring.data.proxy.impl.regular.ToStringNonDataOperationHandler;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -36,6 +37,7 @@ public class NonDataOperationInvocationHandler implements InvocationHandler {
       handlers.add(new EqualsNonDataOperationHandler());
       handlers.add(new HashCodeNonDataOperationHandler());
       handlers.add(new ToStringNonDataOperationHandler());
+      handlers.add(new InterfaceDefaultMethodNonDataOperation());
     }
   }
 
@@ -45,7 +47,7 @@ public class NonDataOperationInvocationHandler implements InvocationHandler {
     for (NonDataOperationHandler handler : handlers) {
       if (handler.handles(proxy, method, args)) {
         log.info("Found handler " + handler + " for method " + method);
-        return handler.invoke(proxy, args);
+        return handler.invoke(proxy, method, args);
       }
     }
     log.error("No data or non-data operation handler could be found for method " + method);

--- a/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/proxy/impl/regular/EqualsNonDataOperationHandler.java
+++ b/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/proxy/impl/regular/EqualsNonDataOperationHandler.java
@@ -26,7 +26,7 @@ public class EqualsNonDataOperationHandler implements NonDataOperationHandler {
   }
 
   @Override
-  public Object invoke(Object proxy, Object... args) {
+  public Object invoke(Object proxy, Method method, Object... args) {
     final Object that = args[0];
     if (that == null || !Proxy.isProxyClass(that.getClass())) {
       return false;

--- a/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/proxy/impl/regular/HashCodeNonDataOperationHandler.java
+++ b/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/proxy/impl/regular/HashCodeNonDataOperationHandler.java
@@ -24,7 +24,7 @@ public class HashCodeNonDataOperationHandler implements NonDataOperationHandler 
   }
 
   @Override
-  public Object invoke(Object proxy, Object... args) {
+  public Object invoke(Object proxy, Method method, Object... args) {
     return Objects.hashCode(superInterfaces(proxy.getClass()).sorted(Comparator.comparing(Class::getCanonicalName)).toArray());
   }
 }

--- a/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/proxy/impl/regular/InterfaceDefaultMethodNonDataOperation.java
+++ b/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/proxy/impl/regular/InterfaceDefaultMethodNonDataOperation.java
@@ -1,0 +1,136 @@
+package com.mmnaseri.utils.spring.data.proxy.impl.regular;
+
+import com.mmnaseri.utils.spring.data.error.DataOperationExecutionException;
+import com.mmnaseri.utils.spring.data.proxy.NonDataOperationHandler;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+/**
+ * An invocation handler that attempts to locate and call an appropriate default method from an interface type.
+ */
+public class InterfaceDefaultMethodNonDataOperation implements NonDataOperationHandler {
+
+  @Override
+  public boolean handles(Object proxy, Method method, Object... args) {
+    return method.isDefault();
+  }
+
+  @Override
+  public Object invoke(Object proxy, Method method, Object... args) {
+    try {
+      return callDefaultMethod(new MethodInvocation(proxy, method, args));
+    } catch (Throwable throwable) {
+      throw new DataOperationExecutionException("Failed to execute default method " + method, throwable);
+    }
+  }
+
+
+  private Object callDefaultMethod(final MethodInvocation invocation) throws Throwable {
+    try {
+      return callDefaultMethodWithLookup(defaultLookup(), invocation);
+    } catch (IllegalAccessException e) {
+      if (e.getMessage().matches(".*no private access for invokespecial.*")) {
+        return tryWithAccessibleLookup(invocation);
+      }
+      throw e;
+    }
+  }
+
+  private Object tryWithAccessibleLookup(final MethodInvocation invocation) throws Throwable {
+    try {
+      return callDefaultMethodWithLookup(accessibleLookup(invocation), invocation);
+    } catch (Throwable throwable) {
+      if (throwable.getClass().getName().equals("java.lang.reflect.InaccessibleObjectException")) {
+        return tryWithPrivateLookup(invocation);
+      }
+      throw throwable;
+    }
+  }
+
+  private Object tryWithPrivateLookup(final MethodInvocation invocation) throws Throwable {
+    return callDefaultMethodWithLookup(privateLookup(invocation), invocation);
+  }
+
+  private MethodHandles.Lookup privateLookup(final MethodInvocation invocation)
+    throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+    Method privateLookupIn =
+      MethodHandles.class.getDeclaredMethod(
+        "privateLookupIn", Class.class, MethodHandles.Lookup.class);
+    return (MethodHandles.Lookup)
+             privateLookupIn.invoke(
+               null, invocation.method().getDeclaringClass(), MethodHandles.lookup());
+  }
+
+  private Object callDefaultMethodWithLookup(
+    MethodHandles.Lookup lookup, MethodInvocation invocation) throws Throwable {
+    try {
+      return lookup
+               .in(invocation.method().getDeclaringClass())
+               .unreflectSpecial(invocation.method(), invocation.instance().getClass())
+               .bindTo(invocation.instance())
+               .invokeWithArguments(invocation.arguments());
+    } catch (IllegalAccessException exception) {
+      if (exception.getMessage().contains("no private access for invokespecial")) {
+        return lookup
+                 .findSpecial(
+                   invocation.method().getDeclaringClass(),
+                   invocation.method().getName(),
+                   MethodType.methodType(
+                     invocation.method().getReturnType(), invocation.method().getParameterTypes()),
+                   invocation.method().getDeclaringClass())
+                 .bindTo(invocation.instance())
+                 .invokeWithArguments(invocation.arguments());
+      } else {
+        throw exception;
+      }
+    }
+  }
+
+  private static MethodHandles.Lookup defaultLookup() {
+    return MethodHandles.lookup();
+  }
+
+  private static MethodHandles.Lookup accessibleLookup(MethodInvocation invocation)
+    throws NoSuchMethodException, IllegalAccessException, InvocationTargetException,
+           InstantiationException {
+    Constructor<MethodHandles.Lookup> constructor =
+      MethodHandles.Lookup.class.getDeclaredConstructor(Class.class);
+    constructor.setAccessible(true);
+    return constructor.newInstance(invocation.method().getDeclaringClass());
+
+  }
+
+
+  private static class MethodInvocation {
+
+    private final Object instance;
+    private final Method method;
+    private final Object[] arguments;
+
+    public MethodInvocation(
+      final Object instance, final Method method, final Object[] arguments) {
+      this.instance = instance;
+      this.arguments = arguments == null ? new Object[0] : Arrays.copyOf(arguments, arguments.length);
+      this.method = method;
+    }
+
+    public Object instance() {
+      return instance;
+    }
+
+    public Object[] arguments() {
+      return Arrays.copyOf(arguments, arguments.length);
+    }
+
+    public Method method() {
+      return method;
+    }
+
+  }
+
+}

--- a/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/proxy/impl/regular/ToStringNonDataOperationHandler.java
+++ b/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/proxy/impl/regular/ToStringNonDataOperationHandler.java
@@ -24,7 +24,7 @@ public class ToStringNonDataOperationHandler implements NonDataOperationHandler 
   }
 
   @Override
-  public Object invoke(Object proxy, Object... args) {
+  public Object invoke(Object proxy, Method method, Object... args) {
     return "mock<" + superInterfaces(proxy.getClass()).sorted(comparing(Class::getCanonicalName)).collect(toList()).toString() + ">";
   }
 }

--- a/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/proxy/impl/DataOperationInvocationHandlerTest.java
+++ b/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/proxy/impl/DataOperationInvocationHandlerTest.java
@@ -57,7 +57,7 @@ public class DataOperationInvocationHandlerTest {
     final Object result =
         handler.invoke(proxy, Object.class.getMethod("hashCode"), new Object[] {});
     assertThat(result, is(notNullValue()));
-    assertThat(result, is(proxy.hashCode()));
+    assertThat(result, is(1));
   }
 
   /** Regression test to reproduce #12 */
@@ -68,8 +68,7 @@ public class DataOperationInvocationHandlerTest {
         handler.invoke(proxy, Object.class.getMethod("equals", Object.class), new Object[] {proxy});
     assertThat(result, is(notNullValue()));
     assertThat(result, is(instanceOf(Boolean.class)));
-    //noinspection ConstantConditions
-    assertThat(result, is(true));
+    assertThat(result, is(false));
   }
 
   /** Regression test to reproduce #12 */
@@ -90,7 +89,7 @@ public class DataOperationInvocationHandlerTest {
     final Object result =
         handler.invoke(proxy, Object.class.getMethod("toString"), new Object[] {});
     assertThat(result, is(notNullValue()));
-    assertThat(result, is(proxy.toString()));
+    assertThat(result, is("mock<[]>"));
   }
 
   @Test

--- a/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/proxy/impl/DefaultMethodTest.java
+++ b/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/proxy/impl/DefaultMethodTest.java
@@ -1,0 +1,41 @@
+package com.mmnaseri.utils.spring.data.proxy.impl;
+
+import com.mmnaseri.utils.spring.data.sample.models.Person;
+import com.mmnaseri.utils.spring.data.sample.repositories.DefaultMethodPersonRepository;
+import com.mmnaseri.utils.spring.data.store.DataStore;
+import com.mmnaseri.utils.spring.data.store.impl.MemoryDataStore;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.mmnaseri.utils.spring.data.dsl.factory.RepositoryFactoryBuilder.builder;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class DefaultMethodTest {
+
+  private DefaultMethodPersonRepository mock;
+  private DataStore<Object, Person> dataStore;
+
+  @BeforeMethod
+  public void setUp() {
+    dataStore = new MemoryDataStore<>(Person.class);
+    mock = builder().registerDataStore(dataStore).mock(DefaultMethodPersonRepository.class);
+  }
+
+  @Test
+  public void testCallingDefaultMethod() {
+    dataStore.save("1", new Person().setId("1").setFirstName("Mohammad").setAge(100));
+    dataStore.save("2", new Person().setId("2").setFirstName("Moses").setAge(110));
+    dataStore.save("3", new Person().setId("3").setFirstName("Milad").setAge(30));
+
+    List<Person> interestingPeople = mock.theInterestingPeople();
+
+    assertThat(interestingPeople, is(notNullValue()));
+    assertThat(interestingPeople, containsInAnyOrder(dataStore.retrieve("1"), dataStore.retrieve("2")));
+  }
+
+}

--- a/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/proxy/impl/NonDataOperationInvocationHandlerTest.java
+++ b/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/proxy/impl/NonDataOperationInvocationHandlerTest.java
@@ -20,13 +20,13 @@ public class NonDataOperationInvocationHandlerTest {
     final Object proxy = new Object();
     assertThat(
         handler.invoke(proxy, Object.class.getMethod("hashCode"), new Object[] {}),
-        Matchers.is(proxy.hashCode()));
+        Matchers.is(1));
     assertThat(
         handler.invoke(proxy, Object.class.getMethod("toString"), new Object[] {}),
-        Matchers.is(proxy.toString()));
+        Matchers.is("mock<[]>"));
     assertThat(
         handler.invoke(proxy, Object.class.getMethod("equals", Object.class), new Object[] {proxy}),
-        Matchers.is(true));
+        Matchers.is(false));
     assertThat(
         handler.invoke(
             proxy, Object.class.getMethod("equals", Object.class), new Object[] {new Object()}),

--- a/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/sample/mocks/SpyingHandler.java
+++ b/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/sample/mocks/SpyingHandler.java
@@ -22,7 +22,7 @@ public class SpyingHandler implements NonDataOperationHandler {
     }
 
     @Override
-    public Object invoke(Object proxy, Object... args) {
+    public Object invoke(Object proxy, Method method, Object... args) {
         called = true;
         return null;
     }

--- a/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/sample/repositories/DefaultMethodPersonRepository.java
+++ b/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/sample/repositories/DefaultMethodPersonRepository.java
@@ -1,0 +1,15 @@
+package com.mmnaseri.utils.spring.data.sample.repositories;
+
+import com.mmnaseri.utils.spring.data.sample.models.Person;
+
+import java.util.List;
+
+public interface DefaultMethodPersonRepository extends SimplePersonRepository {
+
+  List<Person> findByAgeGreaterThan(int age);
+
+  default List<Person> theInterestingPeople() {
+    return findByAgeGreaterThan(99);
+  }
+
+}


### PR DESCRIPTION
This commit adds a new non-data operation handler which supports default
methods via various look-up methods. It also updates the repository factory to
_not_ consider default methods as a viable mapping.

Closes #180