### PR TITLE
Implement Key Generation Strategy

### DIFF
--- a/spring-data-mock/pom.xml
+++ b/spring-data-mock/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>com.mmnaseri.utils</groupId>
     <artifactId>spring-data-mock</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
 
     <name>Spring Data Mock</name>
     <description>A framework for mocking Spring Data repositories</description>

--- a/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/domain/KeyGenerationStrategy.java
+++ b/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/domain/KeyGenerationStrategy.java
@@ -1,0 +1,14 @@
+package com.mmnaseri.utils.spring.data.domain;
+
+public enum KeyGenerationStrategy {
+    /**
+     * Generate a key for {@code null} id values only.
+     */
+    ONLY_NULL,
+
+    /**
+     * Generate a key for all "unmanaged" entites.
+     * Regardless of whether an ID value exists or not.
+     */
+    ALL_UNMANAGED
+}

--- a/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/domain/KeyGeneratorAware.java
+++ b/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/domain/KeyGeneratorAware.java
@@ -10,4 +10,6 @@ package com.mmnaseri.utils.spring.data.domain;
 public interface KeyGeneratorAware<S> {
 
   void setKeyGenerator(KeyGenerator<? extends S> keyGenerator);
+  void setKeyGenerationStrategy(KeyGenerationStrategy strategy);
+
 }

--- a/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/dsl/factory/RepositoryFactoryBuilder.java
+++ b/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/dsl/factory/RepositoryFactoryBuilder.java
@@ -1,9 +1,6 @@
 package com.mmnaseri.utils.spring.data.dsl.factory;
 
-import com.mmnaseri.utils.spring.data.domain.KeyGenerator;
-import com.mmnaseri.utils.spring.data.domain.Operator;
-import com.mmnaseri.utils.spring.data.domain.OperatorContext;
-import com.mmnaseri.utils.spring.data.domain.RepositoryMetadataResolver;
+import com.mmnaseri.utils.spring.data.domain.*;
 import com.mmnaseri.utils.spring.data.domain.impl.DefaultOperatorContext;
 import com.mmnaseri.utils.spring.data.domain.impl.DefaultRepositoryMetadataResolver;
 import com.mmnaseri.utils.spring.data.domain.impl.MethodQueryDescriptionExtractor;
@@ -64,6 +61,7 @@ public class RepositoryFactoryBuilder
   private DataStoreEventListenerContext eventListenerContext;
   private NonDataOperationInvocationHandler operationInvocationHandler;
   private KeyGenerator<?> defaultKeyGenerator;
+  private KeyGenerationStrategy defaultKeyGenerationStrategy;
 
   private RepositoryFactoryBuilder() {
     metadataResolver = new DefaultRepositoryMetadataResolver();
@@ -76,6 +74,7 @@ public class RepositoryFactoryBuilder
     operationInvocationHandler = new NonDataOperationInvocationHandler();
     // by default, we do not want any key generator, unless one is specified
     defaultKeyGenerator = null;
+    defaultKeyGenerationStrategy = KeyGenerationStrategy.ONLY_NULL;
   }
 
   @Override
@@ -251,17 +250,28 @@ public class RepositoryFactoryBuilder
         typeMappingContext,
         eventListenerContext,
         operationInvocationHandler,
-        defaultKeyGenerator);
+        defaultKeyGenerator,
+        defaultKeyGenerationStrategy);
   }
 
   @Override
   public <S> Implementation generateKeysUsing(KeyGenerator<S> keyGenerator) {
-    return new RepositoryMockBuilder().useFactory(build()).generateKeysUsing(keyGenerator);
+    return generateKeysUsing(keyGenerator, defaultKeyGenerationStrategy);
+  }
+
+  @Override
+  public <S> Implementation generateKeysUsing(KeyGenerator<S> keyGenerator, KeyGenerationStrategy keyGenerationStrategy) {
+    return new RepositoryMockBuilder().useFactory(build()).generateKeysUsing(keyGenerator, keyGenerationStrategy);
   }
 
   @Override
   public <S, G extends KeyGenerator<S>> Implementation generateKeysUsing(Class<G> generatorType) {
-    return new RepositoryMockBuilder().useFactory(build()).generateKeysUsing(generatorType);
+    return generateKeysUsing(generatorType, defaultKeyGenerationStrategy);
+  }
+
+  @Override
+  public <S, G extends KeyGenerator<S>> Implementation generateKeysUsing(Class<G> generatorType, KeyGenerationStrategy keyGenerationStrategy) {
+    return new RepositoryMockBuilder().useFactory(build()).generateKeysUsing(generatorType, keyGenerationStrategy);
   }
 
   @Override
@@ -291,7 +301,8 @@ public class RepositoryFactoryBuilder
         builder.typeMappingContext,
         builder.eventListenerContext,
         builder.operationInvocationHandler,
-        builder.defaultKeyGenerator);
+        builder.defaultKeyGenerator,
+        builder.defaultKeyGenerationStrategy);
   }
 
   /**

--- a/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/dsl/mock/KeyGeneration.java
+++ b/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/dsl/mock/KeyGeneration.java
@@ -1,5 +1,6 @@
 package com.mmnaseri.utils.spring.data.dsl.mock;
 
+import com.mmnaseri.utils.spring.data.domain.KeyGenerationStrategy;
 import com.mmnaseri.utils.spring.data.domain.KeyGenerator;
 
 /**
@@ -20,6 +21,17 @@ public interface KeyGeneration extends Implementation {
   <S> Implementation generateKeysUsing(KeyGenerator<S> keyGenerator);
 
   /**
+   * Sets the key generator to the provided instance
+   *
+   * @param keyGenerator the key generator
+   * @param keyGenerationStrategy the key generation strategy
+   * @param <S> the type of the keys
+   * @return the rest of the configuration
+   */
+  <S> Implementation generateKeysUsing(
+      KeyGenerator<S> keyGenerator, KeyGenerationStrategy keyGenerationStrategy);
+
+  /**
    * Sets the key generator to an instance of the provided type.
    *
    * @param generatorType the type of the key generator to use
@@ -28,6 +40,18 @@ public interface KeyGeneration extends Implementation {
    * @return the rest of the configuration
    */
   <S, G extends KeyGenerator<S>> Implementation generateKeysUsing(Class<G> generatorType);
+
+  /**
+   * Sets the key generator to an instance of the provided type.
+   *
+   * @param generatorType the type of the key generator to use
+   * @param keyGenerationStrategy the key generation strategy
+   * @param <S> the type of the keys the generator will be generating
+   * @param <G> the type of the generator
+   * @return the rest of the configuration
+   */
+  <S, G extends KeyGenerator<S>> Implementation generateKeysUsing(
+      Class<G> generatorType, KeyGenerationStrategy keyGenerationStrategy);
 
   /**
    * Tells the builder that we are not going to have any auto-generated keys

--- a/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/proxy/RepositoryFactory.java
+++ b/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/proxy/RepositoryFactory.java
@@ -1,5 +1,6 @@
 package com.mmnaseri.utils.spring.data.proxy;
 
+import com.mmnaseri.utils.spring.data.domain.KeyGenerationStrategy;
 import com.mmnaseri.utils.spring.data.domain.KeyGenerator;
 
 /**
@@ -26,9 +27,30 @@ public interface RepositoryFactory {
    * @param <E> the type of the interface
    * @return a prepared instance of the repository
    * @throws com.mmnaseri.utils.spring.data.error.RepositoryMockException should anything go wrong
+   * @deprecated Use {@link #getInstance(KeyGenerator, KeyGenerationStrategy, Class, Class[])} instead.
+   */
+  @Deprecated
+  default <E> E getInstance(
+      KeyGenerator<?> keyGenerator, Class<E> repositoryInterface, Class... implementations) {
+    return getInstance(keyGenerator, KeyGenerationStrategy.ONLY_NULL, repositoryInterface, implementations);
+  }
+
+  /**
+   * Creates an instance of the repository as per the provided configuration.
+   *
+   * @param keyGenerator the key generator to use when inserting items (if auto generation is
+   *     required). You can specify a {@literal null} key generator to signify that {@link
+   *     RepositoryFactoryConfiguration#getDefaultKeyGenerator() the fallback key generator} should
+   *     be used when generating keys.
+   * @param keyGenerationStrategy the strategy when and for which entities a key should be generated.
+   * @param repositoryInterface the repository interface which we want to mock
+   * @param implementations all the concrete classes that can be used to figure out method mappings
+   * @param <E> the type of the interface
+   * @return a prepared instance of the repository
+   * @throws com.mmnaseri.utils.spring.data.error.RepositoryMockException should anything go wrong
    */
   <E> E getInstance(
-      KeyGenerator<?> keyGenerator, Class<E> repositoryInterface, Class... implementations);
+        KeyGenerator<?> keyGenerator, KeyGenerationStrategy keyGenerationStrategy, Class<E> repositoryInterface, Class... implementations);
 
   /** @return the configuration bound to this repository factory */
   RepositoryFactoryConfiguration getConfiguration();

--- a/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/proxy/RepositoryFactoryConfiguration.java
+++ b/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/proxy/RepositoryFactoryConfiguration.java
@@ -1,5 +1,6 @@
 package com.mmnaseri.utils.spring.data.proxy;
 
+import com.mmnaseri.utils.spring.data.domain.KeyGenerationStrategy;
 import com.mmnaseri.utils.spring.data.domain.KeyGenerator;
 import com.mmnaseri.utils.spring.data.domain.RepositoryMetadataResolver;
 import com.mmnaseri.utils.spring.data.domain.impl.MethodQueryDescriptionExtractor;
@@ -46,4 +47,10 @@ public interface RepositoryFactoryConfiguration {
    *     specified
    */
   KeyGenerator<?> getDefaultKeyGenerator();
+
+  /**
+   * @return the default key generation strategy that should be used as a fallback when no strategy is
+   *     specified
+   */
+  KeyGenerationStrategy getDefaultKeyGenerationStrategy();
 }

--- a/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/proxy/impl/DefaultRepositoryFactoryConfiguration.java
+++ b/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/proxy/impl/DefaultRepositoryFactoryConfiguration.java
@@ -1,5 +1,6 @@
 package com.mmnaseri.utils.spring.data.proxy.impl;
 
+import com.mmnaseri.utils.spring.data.domain.KeyGenerationStrategy;
 import com.mmnaseri.utils.spring.data.domain.KeyGenerator;
 import com.mmnaseri.utils.spring.data.domain.RepositoryMetadataResolver;
 import com.mmnaseri.utils.spring.data.domain.impl.MethodQueryDescriptionExtractor;
@@ -27,6 +28,7 @@ public class DefaultRepositoryFactoryConfiguration implements RepositoryFactoryC
   private DataStoreEventListenerContext eventListenerContext;
   private NonDataOperationInvocationHandler operationInvocationHandler;
   private KeyGenerator<?> defaultKeyGenerator;
+  private KeyGenerationStrategy defaultKeyGenerationStrategy;
 
   public DefaultRepositoryFactoryConfiguration() {}
 
@@ -40,7 +42,31 @@ public class DefaultRepositoryFactoryConfiguration implements RepositoryFactoryC
         configuration.getTypeMappingContext(),
         configuration.getEventListenerContext(),
         configuration.getOperationInvocationHandler(),
-        configuration.getDefaultKeyGenerator());
+        configuration.getDefaultKeyGenerator(),
+        configuration.getDefaultKeyGenerationStrategy());
+  }
+
+  @Deprecated
+  public DefaultRepositoryFactoryConfiguration(
+      RepositoryMetadataResolver repositoryMetadataResolver,
+      MethodQueryDescriptionExtractor descriptionExtractor,
+      DataFunctionRegistry functionRegistry,
+      DataStoreRegistry dataStoreRegistry,
+      ResultAdapterContext resultAdapterContext,
+      TypeMappingContext typeMappingContext,
+      DataStoreEventListenerContext eventListenerContext,
+      NonDataOperationInvocationHandler operationInvocationHandler,
+      KeyGenerator<?> defaultKeyGenerator) {
+    this(repositoryMetadataResolver,
+            descriptionExtractor,
+            functionRegistry,
+            dataStoreRegistry,
+            resultAdapterContext,
+            typeMappingContext,
+            eventListenerContext,
+            operationInvocationHandler,
+            defaultKeyGenerator,
+            KeyGenerationStrategy.ONLY_NULL);
   }
 
   public DefaultRepositoryFactoryConfiguration(
@@ -52,7 +78,8 @@ public class DefaultRepositoryFactoryConfiguration implements RepositoryFactoryC
       TypeMappingContext typeMappingContext,
       DataStoreEventListenerContext eventListenerContext,
       NonDataOperationInvocationHandler operationInvocationHandler,
-      KeyGenerator<?> defaultKeyGenerator) {
+      KeyGenerator<?> defaultKeyGenerator,
+      KeyGenerationStrategy defaultKeyGenerationStrategy) {
     this.repositoryMetadataResolver = repositoryMetadataResolver;
     this.descriptionExtractor = descriptionExtractor;
     this.functionRegistry = functionRegistry;
@@ -62,6 +89,7 @@ public class DefaultRepositoryFactoryConfiguration implements RepositoryFactoryC
     this.eventListenerContext = eventListenerContext;
     this.operationInvocationHandler = operationInvocationHandler;
     this.defaultKeyGenerator = defaultKeyGenerator;
+    this.defaultKeyGenerationStrategy = defaultKeyGenerationStrategy;
   }
 
   @Override
@@ -144,5 +172,14 @@ public class DefaultRepositoryFactoryConfiguration implements RepositoryFactoryC
 
   public void setDefaultKeyGenerator(KeyGenerator<?> defaultKeyGenerator) {
     this.defaultKeyGenerator = defaultKeyGenerator;
+  }
+
+  @Override
+  public KeyGenerationStrategy getDefaultKeyGenerationStrategy() {
+    return defaultKeyGenerationStrategy;
+  }
+
+  public void setDefaultKeyGenerationStrategy(KeyGenerationStrategy defaultKeyGenerationStrategy) {
+    this.defaultKeyGenerationStrategy = defaultKeyGenerationStrategy;
   }
 }

--- a/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/proxy/impl/ImmutableRepositoryFactoryConfiguration.java
+++ b/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/proxy/impl/ImmutableRepositoryFactoryConfiguration.java
@@ -1,5 +1,6 @@
 package com.mmnaseri.utils.spring.data.proxy.impl;
 
+import com.mmnaseri.utils.spring.data.domain.KeyGenerationStrategy;
 import com.mmnaseri.utils.spring.data.domain.KeyGenerator;
 import com.mmnaseri.utils.spring.data.domain.RepositoryMetadataResolver;
 import com.mmnaseri.utils.spring.data.domain.impl.MethodQueryDescriptionExtractor;
@@ -29,6 +30,7 @@ public class ImmutableRepositoryFactoryConfiguration implements RepositoryFactor
   private final DataStoreEventListenerContext eventListenerContext;
   private final NonDataOperationInvocationHandler operationInvocationHandler;
   private final KeyGenerator<?> keyGenerator;
+  private final KeyGenerationStrategy keyGenerationStrategy;
 
   public ImmutableRepositoryFactoryConfiguration(RepositoryFactoryConfiguration configuration) {
     this(
@@ -40,7 +42,31 @@ public class ImmutableRepositoryFactoryConfiguration implements RepositoryFactor
         configuration.getTypeMappingContext(),
         configuration.getEventListenerContext(),
         configuration.getOperationInvocationHandler(),
-        configuration.getDefaultKeyGenerator());
+        configuration.getDefaultKeyGenerator(),
+        configuration.getDefaultKeyGenerationStrategy());
+  }
+
+  @Deprecated
+  public ImmutableRepositoryFactoryConfiguration(
+      RepositoryMetadataResolver metadataResolver,
+      MethodQueryDescriptionExtractor queryDescriptionExtractor,
+      DataFunctionRegistry functionRegistry,
+      DataStoreRegistry dataStoreRegistry,
+      ResultAdapterContext resultAdapterContext,
+      TypeMappingContext typeMappingContext,
+      DataStoreEventListenerContext eventListenerContext,
+      NonDataOperationInvocationHandler operationInvocationHandler,
+      KeyGenerator<?> keyGenerator) {
+    this(metadataResolver,
+            queryDescriptionExtractor,
+            functionRegistry,
+            dataStoreRegistry,
+            resultAdapterContext,
+            typeMappingContext,
+            eventListenerContext,
+            operationInvocationHandler,
+            keyGenerator,
+            KeyGenerationStrategy.ONLY_NULL);
   }
 
   public ImmutableRepositoryFactoryConfiguration(
@@ -52,7 +78,8 @@ public class ImmutableRepositoryFactoryConfiguration implements RepositoryFactor
       TypeMappingContext typeMappingContext,
       DataStoreEventListenerContext eventListenerContext,
       NonDataOperationInvocationHandler operationInvocationHandler,
-      KeyGenerator<?> keyGenerator) {
+      KeyGenerator<?> keyGenerator,
+      KeyGenerationStrategy keyGenerationStrategy) {
     this.metadataResolver = metadataResolver;
     this.queryDescriptionExtractor = queryDescriptionExtractor;
     this.functionRegistry = functionRegistry;
@@ -62,6 +89,7 @@ public class ImmutableRepositoryFactoryConfiguration implements RepositoryFactor
     this.eventListenerContext = eventListenerContext;
     this.operationInvocationHandler = operationInvocationHandler;
     this.keyGenerator = keyGenerator;
+    this.keyGenerationStrategy = keyGenerationStrategy;
   }
 
   @Override
@@ -107,5 +135,10 @@ public class ImmutableRepositoryFactoryConfiguration implements RepositoryFactor
   @Override
   public KeyGenerator<?> getDefaultKeyGenerator() {
     return keyGenerator;
+  }
+
+  @Override
+  public KeyGenerationStrategy getDefaultKeyGenerationStrategy() {
+    return keyGenerationStrategy;
   }
 }

--- a/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/repository/DefaultCrudRepositoryWithAllUnamangedKeyGenerationStrategyTest.java
+++ b/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/repository/DefaultCrudRepositoryWithAllUnamangedKeyGenerationStrategyTest.java
@@ -1,0 +1,81 @@
+package com.mmnaseri.utils.spring.data.repository;
+
+import com.mmnaseri.utils.spring.data.domain.KeyGenerationStrategy;
+import com.mmnaseri.utils.spring.data.domain.impl.ImmutableRepositoryMetadata;
+import com.mmnaseri.utils.spring.data.domain.impl.key.UUIDKeyGenerator;
+import com.mmnaseri.utils.spring.data.error.EntityMissingKeyException;
+import com.mmnaseri.utils.spring.data.sample.models.Person;
+import com.mmnaseri.utils.spring.data.sample.repositories.SimplePersonRepository;
+import com.mmnaseri.utils.spring.data.store.DataStore;
+import com.mmnaseri.utils.spring.data.store.impl.MemoryDataStore;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+
+import static com.mmnaseri.utils.spring.data.utils.TestUtils.iterableToList;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * @author Milad Naseri (m.m.naseri@gmail.com)
+ * @since 1.0 (4/11/16, 10:15 AM)
+ */
+public class DefaultCrudRepositoryWithAllUnamangedKeyGenerationStrategyTest {
+
+    private DefaultCrudRepository repository;
+    private DataStore<String, Person> dataStore;
+
+    @BeforeMethod
+    public void setUp() {
+        dataStore = new MemoryDataStore<>(Person.class);
+        repository = new DefaultCrudRepository();
+        repository.setRepositoryMetadata(
+                new ImmutableRepositoryMetadata(String.class, Person.class, SimplePersonRepository.class, "id"));
+        repository.setDataStore(dataStore);
+        repository.setKeyGenerator(new UUIDKeyGenerator());
+        repository.setKeyGenerationStrategy(KeyGenerationStrategy.ALL_UNMANAGED);
+    }
+
+    @Test
+    public void testSave() {
+        final Person managedPerson = new Person().setId("4");
+        dataStore.save(managedPerson.getId(), managedPerson);
+        final List<Person> entities = Arrays.asList(
+                new Person().setId("1"),
+                new Person().setId("2"),
+                new Person().setId("3"),
+                managedPerson
+        );
+        final Iterable<Object> inserted = repository.saveAll(entities);
+        assertThat(inserted, is(notNullValue()));
+        final List<Object> insertedList = StreamSupport.stream(inserted.spliterator(), /* parallel= */ false).collect(toList());
+        assertThat(insertedList, hasSize(4));
+        for (Object item : insertedList) {
+            assertThat(item, is(instanceOf(Person.class)));
+            assertThat((Person) item, isIn(entities));
+            assertThat(((Person) item).getId(), is(notNullValue()));
+            if (managedPerson == item) {
+                assertThat(((Person) item).getId(), is("4"));
+            } else {
+                assertThat(((Person) item).getId(), not(isOneOf("1", "2", "3")));
+            }
+        }
+        assertThat(dataStore.retrieveAll(), hasSize(entities.size()));
+        final Iterable<Object> updated = repository.saveAll(entities);
+        assertThat(updated, is(notNullValue()));
+        final List<Object> updatedList = StreamSupport.stream(updated.spliterator(), /* parallel= */ false).collect(toList());
+        assertThat(updatedList, hasSize(4));
+        for (Object item : updatedList) {
+            assertThat(item, is(instanceOf(Person.class)));
+            assertThat((Person) item, isIn(entities));
+        }
+        assertThat(dataStore.retrieveAll(), hasSize(entities.size()));
+    }
+
+}

--- a/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/sample/usecases/proxy/InformationExposingRepositoryFactory.java
+++ b/spring-data-mock/src/test/java/com/mmnaseri/utils/spring/data/sample/usecases/proxy/InformationExposingRepositoryFactory.java
@@ -1,5 +1,6 @@
 package com.mmnaseri.utils.spring.data.sample.usecases.proxy;
 
+import com.mmnaseri.utils.spring.data.domain.KeyGenerationStrategy;
 import com.mmnaseri.utils.spring.data.domain.KeyGenerator;
 import com.mmnaseri.utils.spring.data.proxy.RepositoryConfiguration;
 import com.mmnaseri.utils.spring.data.proxy.RepositoryFactory;
@@ -25,8 +26,8 @@ public class InformationExposingRepositoryFactory implements RepositoryFactory {
     }
 
     @Override
-    public <E> E getInstance(KeyGenerator<?> keyGenerator, Class<E> repositoryInterface, Class... implementations) {
-        final E instance = delegate.getInstance(keyGenerator, repositoryInterface, implementations);
+    public <E> E getInstance(KeyGenerator<?> keyGenerator, KeyGenerationStrategy keyGenerationStrategy, Class<E> repositoryInterface, Class... implementations) {
+        final E instance = delegate.getInstance(keyGenerator, keyGenerationStrategy, repositoryInterface, implementations);
         //noinspection unchecked
         final RepositoryConfiguration configuration = new ImmutableRepositoryConfiguration(
                 this.configuration.getRepositoryMetadataResolver().resolve(repositoryInterface), keyGenerator,


### PR DESCRIPTION
The current implementation only generates IDs for NULL values.
But in JPA or in particular Hibernate generates a new ID for all unmanaged entities (If an ID generator is used).

In Kotlin in particular, this can be exploited as follows:

```kotlin
@Entity
data class Media(
  @Id
  @Column(nullable = false)
  @GeneratedValue
  var id: UUID = UUID(0, 0)
)
```

The "id" field is initialized with a 0-UUID and is never NULL.
This is a popular approach, mainly because of the [NULL safety in Kotlin](https://kotlinlang.org/docs/null-safety.html).
In order not to change the previous behavior, there is now a KeyGenerationStrategy with which you can change the behavior:

```kotlin
val repository = RepositoryFactoryBuilder
    .builder()
    .generateKeysUsing(UUIDObjectTypeKeyGenerator::class.java, KeyGenerationStrategy.ALL_UNMANAGED)
    .mock(MyRepository::class.java)
```

An entity that is not yet contained in the DataStore is seen as "unmanaged".


---

Besides, the mock is not really complete.
When an "unmanaged" entity is saved, Hibernate usually creates a clone.
This is therefore useful in order to prevent side effects from object manipulation.
The mock does not do that, which for example leads to the following code not working (in JPA + Hibernate, however, it does):

```kotlin
class Controller {
  fun userDetails(id: UUID): User {
    val user = repository.findByIdOrNull(id)
    user.eraseCredentials() // Manipulation of the object also manipulates the DataStore
    return user
  }
}
```

However, a (serialized) clone should perhaps be saved in the DataStore in order to prevent manipulation in the DataStore?