### PR TITLE
Added UUIDObjectTypeKeyGenerator

### DIFF
--- a/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/domain/impl/key/UUIDObjectTypeKeyGenerator.java
+++ b/spring-data-mock/src/main/java/com/mmnaseri/utils/spring/data/domain/impl/key/UUIDObjectTypeKeyGenerator.java
@@ -1,0 +1,16 @@
+package com.mmnaseri.utils.spring.data.domain.impl.key;
+
+import com.mmnaseri.utils.spring.data.domain.KeyGenerator;
+
+import java.util.UUID;
+
+/**
+ * This class will generate unique UUIDs for use in entities.
+ */
+public class UUIDObjectTypeKeyGenerator implements KeyGenerator<UUID> {
+
+  @Override
+  public UUID generate() {
+    return UUID.randomUUID();
+  }
+}


### PR DESCRIPTION
I have no idea why the UUIDKeyGenerator is generating a string.
Usually you should use an UUID object as an ID.
Saving a UUID as a string is very inefficient, both in the Java heap and in the database (some databases even have their own UUID field type, [postgres for example](https://www.postgresql.org/docs/current/datatype-uuid.html)).
The UUIDObjectTypeKeyGenerator creates a UUID object instead of a string.